### PR TITLE
feat: Add metadata to a message request

### DIFF
--- a/lib/pact/consumer_contract/message.rb
+++ b/lib/pact/consumer_contract/message.rb
@@ -64,7 +64,8 @@ module Pact
               providerStates: [{
                 name: provider_state,
                 params: {}
-              }]
+              }],
+              metadata: metadata
             }
           )
         end


### PR DESCRIPTION
Adds metadata to a provider message server. 

Similar issue on pact-jvm: https://github.com/DiUS/pact-jvm/issues/479