### PR TITLE
feat: allow pact-message update to receive JSON via the standard input

### DIFF
--- a/lib/pact/message/cli.rb
+++ b/lib/pact/message/cli.rb
@@ -9,13 +9,23 @@ module Pact
       method_option :pact_dir, required: true, desc: "The Pact directory"
       method_option :pact_specification_version, required: false, default: "2.0.0", desc: "The Pact Specification version"
 
-      desc 'update MESSAGE_JSON', 'Update a pact with the given message, or create the pact if it does not exist. The MESSAGE_JSON may be in the legacy Ruby JSON format or the v2+ format.'
-      def update(message)
+      # Update a pact with the given message, or create the pact if it does not exist
+      desc 'update MESSAGE_JSON', "Update/create a pact. If MESSAGE_JSON is omitted or '-', it is read from stdin"
+      long_desc <<-MSG, wrapping: false
+        Update a pact with the given message, or create the pact if it does not exist.
+        The MESSAGE_JSON may be in the legacy Ruby JSON format or the v2+ format.
+        If MESSAGE_JSON is not provided or is '-', the content will be read from 
+        standard input.
+      MSG
+      def update(maybe_json = '-')
         require 'pact/message'
         require 'pact/message/consumer/write_pact'
+
+        message_json = JSON.parse(maybe_json == '-' ? $stdin.read : maybe_json)
+
         pact_specification_version = Pact::SpecificationVersion.new(options.pact_specification_version)
-        message = Pact::Message.from_hash(JSON.load(message), { pact_specification_version: pact_specification_version })
-        Pact::Message::Consumer::WritePact.call(message, options.pact_dir, options.consumer, options.provider, options.pact_specification_version, :update)
+        message_hash = Pact::Message.from_hash(message_json, { pact_specification_version: pact_specification_version })
+        Pact::Message::Consumer::WritePact.call(message_hash, options.pact_dir, options.consumer, options.provider, options.pact_specification_version, :update)
       end
 
       desc 'reify', "Take a JSON document with embedded pact matchers and return a concrete example"

--- a/spec/features/cli_spec.rb
+++ b/spec/features/cli_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe "the CLI" do
     expect(exit_status).to eq 0
     expect(File.exist?(CLI_SPEC_PACT_FILE_PATH)).to be true
   end
+
+  it "creates a pact file with a message from the standard input" do
+    output = `echo '#{json}' | bundle exec bin/pact-message update --consumer Foo --provider Bar --pact-dir ./tmp`
+    exit_status = $?
+    puts output if exit_status != 0
+    expect(exit_status).to eq 0
+    expect(File.exist?(CLI_SPEC_PACT_FILE_PATH)).to be true
+  end
 end


### PR DESCRIPTION
Fix issue [#61](https://github.com/pact-foundation/pact-ruby-standalone/issues/61) on [pact-ruby-standalone](https://github.com/pact-foundation/pact-ruby-standalone)

@TimothyJones made me do this. I obliged :).
