### PR TITLE
Feature/refactor cli tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,56 @@ Provider states work the same way for Message Pact as they do for HTTP Pact. Ple
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+### Setup
+
+After checking out the repo, run the following to install dependencies.
+
+```bash
+$ bundle exec bin/setup
+
+bundle install
+\+ bundle install
+...
+Bundle complete! 6 Gemfile dependencies, 29 gems now installed.
+Use `bundle info [gemname]` to see where a bundled gem is installed.
+
+Do any other automated setup that you need to do here
+```
+
+### Tests
+
+Run the following command to run the tests.
+
+```bash
+$ bundle exec rake spec
+
+the CLI
+  creates a pact file with the given message
+  creates a pact file with a message from the standard input
+...
+Finished in 0.50883 seconds (files took 0.15053 seconds to load)
+26 examples, 0 failures, 2 pending
+```
+
+### Interactive Prompt
+
+You can run the following command for an for an interactive prompt that will allow you to experiment.
+
+```bash
+$ bundle exec bin/console
+2.6.6 :001 >
+```
+
+To execute commands on the CLI run the following command followed by command line arguments as you would with the published version.
+
+```bash
+$ bundle exec bin/pact-message
+Commands:
+  pact-message help [COMMAND]                                                                   # Describe available commands or one specific command
+  pact-message reify                                                                            # Take a JSON document with embedded pact matchers and return...
+  pact-message update MESSAGE_JSON --consumer=CONSUMER --pact-dir=PACT_DIR --provider=PROVIDER  # Update/create a pact. If MESSAGE_JSON is omitted or '-', it...
+  pact-message version                                                                          # Show the pact-message gem version
+```
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/pact/message/cli.rb
+++ b/lib/pact/message/cli.rb
@@ -9,13 +9,23 @@ module Pact
       method_option :pact_dir, required: true, desc: "The Pact directory"
       method_option :pact_specification_version, required: false, default: "2.0.0", desc: "The Pact Specification version"
 
-      desc 'update MESSAGE_JSON', 'Update a pact with the given message, or create the pact if it does not exist. The MESSAGE_JSON may be in the legacy Ruby JSON format or the v2+ format.'
-      def update(message)
+      # Update a pact with the given message, or create the pact if it does not exist
+      desc 'update MESSAGE_JSON', "Update/create a pact. If MESSAGE_JSON is omitted or '-', it is read from stdin"
+      long_desc <<-MSG, wrapping: false
+        Update a pact with the given message, or create the pact if it does not exist.
+        The MESSAGE_JSON may be in the legacy Ruby JSON format or the v2+ format.
+        If MESSAGE_JSON is not provided or is '-', the content will be read from 
+        standard input.
+      MSG
+      def update(maybe_json = '-')
         require 'pact/message'
         require 'pact/message/consumer/write_pact'
+
+        message_json = JSON.parse(maybe_json == '-' ? $stdin.read : maybe_json)
+
         pact_specification_version = Pact::SpecificationVersion.new(options.pact_specification_version)
-        message = Pact::Message.from_hash(JSON.load(message), { pact_specification_version: pact_specification_version })
-        Pact::Message::Consumer::WritePact.call(message, options.pact_dir, options.consumer, options.provider, options.pact_specification_version, :update)
+        message_hash = Pact::Message.from_hash(message_json, { pact_specification_version: pact_specification_version })
+        Pact::Message::Consumer::WritePact.call(message_hash, options.pact_dir, options.consumer, options.provider, options.pact_specification_version, :update)
       end
 
       desc 'reify', "Take a JSON document with embedded pact matchers and return a concrete example"

--- a/spec/features/cli_spec.rb
+++ b/spec/features/cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'English'
 

--- a/spec/features/cli_spec.rb
+++ b/spec/features/cli_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe "the CLI" do
     expect(exit_status).to eq 0
     expect(File.exist?(CLI_SPEC_PACT_FILE_PATH)).to be true
   end
+
+  it "creates a pact file with a message from the standard input" do
+    output = `echo '#{json}' | bundle exec bin/pact-message update --consumer Foo --provider Bar --pact-dir ./tmp`
+    exit_status = $?
+    puts output if exit_status != 0
+    expect(exit_status).to eq 0
+    expect(File.exist?(CLI_SPEC_PACT_FILE_PATH)).to be true
+  end
 end

--- a/spec/features/cli_spec.rb
+++ b/spec/features/cli_spec.rb
@@ -1,27 +1,40 @@
 require 'fileutils'
+require 'English'
 
-RSpec.describe "the CLI" do
-  CLI_SPEC_PACT_FILE_PATH = "./tmp/foo-bar.json"
-
-  before do
-    FileUtils.rm_rf CLI_SPEC_PACT_FILE_PATH
-  end
+RSpec.describe 'the CLI' do
+  CLI_SPEC_PACT_FILE_PATH = './tmp/foo-bar.json'.freeze
 
   let(:json) { File.read('spec/fixtures/message-v1-format.json') }
+  let(:command) { 'bundle exec bin/pact-message help' }
 
-  it "creates a pact file with the given message" do
-    output = `bundle exec bin/pact-message update '#{json}' --consumer Foo --provider Bar --pact-dir ./tmp`
-    exit_status = $?
-    puts output if exit_status != 0
-    expect(exit_status).to eq 0
-    expect(File.exist?(CLI_SPEC_PACT_FILE_PATH)).to be true
+  RSpec.shared_examples 'terminate successully to create pact file' do
+    before do
+      FileUtils.rm_rf CLI_SPEC_PACT_FILE_PATH
+      `#{command}`
+    end
+
+    it { expect($CHILD_STATUS).to be_success }
+
+    it 'is expected to create a pact file' do
+      expect(File).to exist(CLI_SPEC_PACT_FILE_PATH)
+    end
   end
 
-  it "creates a pact file with a message from the standard input" do
-    output = `echo '#{json}' | bundle exec bin/pact-message update --consumer Foo --provider Bar --pact-dir ./tmp`
-    exit_status = $?
-    puts output if exit_status != 0
-    expect(exit_status).to eq 0
-    expect(File.exist?(CLI_SPEC_PACT_FILE_PATH)).to be true
+  context 'when providing a message' do
+    let(:command) { "bundle exec bin/pact-message update '#{json}' --consumer Foo --provider Bar --pact-dir ./tmp" }
+
+    include_examples 'terminate successully to create pact file'
+  end
+
+  context 'when piping the message from standard input' do
+    let(:command) { "echo '#{json}' | bundle exec bin/pact-message update --consumer Foo --provider Bar --pact-dir ./tmp" }
+
+    include_examples 'terminate successully to create pact file'
+  end
+
+  context 'when piping the message from standard input with a dash' do
+    let(:command) { "echo '#{json}' | bundle exec bin/pact-message update - --consumer Foo --provider Bar --pact-dir ./tmp" }
+
+    include_examples 'terminate successully to create pact file'
   end
 end


### PR DESCRIPTION
I've refactored the CLI spec file to allow for more code reuse and improve the reporting of the `rake spec` command.

```
$ rake spec spec/features/cli_spec.rb 
the CLI
  when providing a message
    is expected to be success
    is expected to create a pact file
  when piping the message from standard input
    is expected to be success
    is expected to create a pact file
  when piping the message from standard input with a dash
    is expected to be success
    is expected to create a pact file

...
```

If the spec file is too hard to read, then this is probably not worth it.