### PR TITLE
feat([PoC]): Contract for sequence of messages.

### DIFF
--- a/lib/pact/consumer_contract/message.rb
+++ b/lib/pact/consumer_contract/message.rb
@@ -13,13 +13,15 @@ module Pact
       include Pact::ActiveSupportSupport
       include Pact::SymbolizeKeys
 
-        attr_accessor :description, :contents, :provider_state, :provider_states, :metadata, :_id, :index
+        attr_accessor :description, :descriptions, :contents, :events, :provider_state, :provider_states, :metadata, :_id, :index
 
         def initialize attributes = {}
           @description = attributes[:description]
+          @descriptions = []
           @provider_state = attributes[:provider_state] || attributes[:providerState]
           @provider_states = attributes[:provider_states] || []
           @contents = attributes[:contents]
+          @events = []
           @metadata = attributes[:metadata]
           @_id = attributes[:_id]
           @index = attributes[:index]

--- a/lib/pact/message/consumer/interaction_builder.rb
+++ b/lib/pact/message/consumer/interaction_builder.rb
@@ -13,6 +13,7 @@ module Pact
         end
 
         def is_expected_to_send description
+          @interaction.descriptions << description
           @interaction.description = description
           self
         end
@@ -32,7 +33,9 @@ module Pact
         end
 
         def with_content(object)
-          interaction.contents = Pact::Message::Contents.from_hash(object)
+          message_content = Pact::Message::Contents.from_hash(object)
+          interaction.events << message_content
+          interaction.contents = message_content
           @callback.call interaction
           self
         end

--- a/lib/pact/message/consumer/interaction_decorator.rb
+++ b/lib/pact/message/consumer/interaction_decorator.rb
@@ -13,7 +13,7 @@ module Pact
         end
 
         def as_json options = {}
-          hash = { :description => message.description }
+          hash = { :description => message.descriptions.join(';') }
           hash[:providerStates] = provider_states
           hash[:contents] = extract_contents
           hash[:matchingRules] = extract_matching_rules
@@ -36,7 +36,9 @@ module Pact
         end
 
         def extract_contents
-          Pact::Reification.from_term(message.contents.contents)
+          message.events.map do |message_content|
+            Pact::Reification.from_term(message_content.contents)
+          end
         end
 
         def provider_states


### PR DESCRIPTION
📓 This PR is just a PoC on how to use Pact for a sequence of messages in a single test iteration. However, this approach is opposite to Consumer-driven Contract Testing (CDC), because is test should be as much simple as possible to test only one iteration (request-response) at a time.

When a Consumer expects a few messages in one test iteration current Pact is keeping only the last message in Contract, this modification makes Pact keeps all messages in Contract.
```ruby
describe TestMessageConsumer do
  let(:expected_payload_1) {
    {
      "first_name": "John",
      "last_name": "Doe"
    }
  }
  let(:expected_payload_2) {
    {
      "hello": "world"
    }
  }
  let(:consumer) { described_class.new }

  describe "Test Message Consumer", pact: :message do
    it "generates contract" do
      test_message_producer
        .given("Class1")
        .is_expected_to_send("created")
        .with_content(expected_payload_1)
      test_message_producer.send_message_string do |content_string|
        expect(consumer.consume_message(content_string)).to eq(expected_payload_1.to_json)
      end

      test_message_producer
        .given("Class2")
        .is_expected_to_send("updated")
        .with_content(expected_payload_2)
      test_message_producer.send_message_string do |content_string|
        expect(consumer.consume_message(content_string)).to eq(expected_payload_2.to_json)
      end
    end
  end
end
```
Contract:
```json
{
  "consumer": {
    "name": "Test Message Consumer"
  },
  "provider": {
    "name": "Test Message Producer"
  },
  "messages": [
    {
      "description": "created;updated",
      "providerStates": [
        {
          "name": "Class1",
          "params": {
          }
        },
        {
          "name": "Class2",
          "params": {
          }
        }
      ],
      "contents": [
        {
          "first_name": "John",
          "last_name": "Doe"
        },
        {
          "hello": "world"
        }
      ],
      "matchingRules": {
      }
    }
  ],
  "metadata": {
    "pactSpecification": {
      "version": "2.0.0"
    }
  }
}
```
See demo: https://github.com/AndrewJanuary/pact-ruby-demo/pull/1