### PR TITLE
Ruby 3 2

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: release-gem

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,16 +4,12 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: "ubuntu-latest"
-    continue-on-error: ${{ matrix.experimental }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.2", "2.7"]
-        experimental: [false]
-        include:
-          - ruby_version: "3.0"
-            experimental: true
+        ruby_version: ["2.2", "2.7", "3.0", "3.2"]
+        os: ["ubuntu-latest","windows-latest","macos-latest"]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.2", "2.7", "3.0", "3.2"]
+        ruby_version: ["2.7", "3.0", "3.2"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.7", "3.0", "3.2"]
+        ruby_version: ["2.7", "3.0", "3.1", "3.2"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/spec/features/cli_spec.rb
+++ b/spec/features/cli_spec.rb
@@ -3,7 +3,7 @@
 require 'fileutils'
 require 'English'
 
-RSpec.describe 'the CLI' do
+RSpec.describe 'the CLI', skip_windows: true do
   CLI_SPEC_PACT_FILE_PATH = './tmp/foo-bar.json'.freeze
 
   let(:json) { File.read('spec/fixtures/message-v1-format.json') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,9 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = ".rspec_status"
 
   config.disable_monkey_patching!
+  is_windows = Gem.win_platform?
 
+  config.filter_run_excluding :skip_windows => is_windows
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
As per https://github.com/pact-foundation/devrel/issues/10

- Tests CI x-platform (windows & macos now included, linux already covered) - x86_64 architecture only
  - Skips failing tests on windows, marked with `skip_windows`
- Tests up to Ruby 3.2
  -  Drops Ruby 2.4 from test matrix
- Updates actions tags