### PR TITLE
fix: require ostruct for OpenStruct name errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.7", "3.0", "3.1", "3.2"]
+        ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/spec/features/create_message_pact_spec.rb
+++ b/spec/features/create_message_pact_spec.rb
@@ -1,6 +1,7 @@
 require "pact/message/consumer/rspec"
 require "fileutils"
 require "pact/helpers"
+require "ostruct"
 
 RSpec.describe "creating a message pact" do
 

--- a/spec/features/create_message_pact_with_failure_test.rb
+++ b/spec/features/create_message_pact_with_failure_test.rb
@@ -1,5 +1,6 @@
 require "pact/message/consumer/rspec"
 require "fileutils"
+require "ostruct"
 
 RSpec.describe "creating a message pact with a failure" do
 


### PR DESCRIPTION
Same error as seen in pact_broker-client https://github.com/pact-foundation/pact_broker-client/pull/155

```
  1) creating a message pact with a string message allows a consumer to test that it can handle the expected message
     Failure/Error: message = OpenStruct.new(JSON.parse(content_string))

     NameError:
       uninitialized constant StringMessageHandler::OpenStruct
     # ./spec/features/create_message_pact_spec.rb:37:in `call'
     # ./spec/features/create_message_pact_spec.rb:89:in `block (4 levels) in <top (required)>'
     # ./lib/pact/message/consumer/consumer_contract_builder.rb:37:in `send_message_string'
     # ./spec/features/create_message_pact_spec.rb:88:in `block (3 levels) in <top (required)>'
```